### PR TITLE
[Feature] mysql2 연동 및 user 테이블 관련 helper 함수

### DIFF
--- a/db/db_helper.js
+++ b/db/db_helper.js
@@ -1,0 +1,38 @@
+import mysql from 'mysql2/promise';
+
+const
+{
+    DB_USER,
+    DB_PASSWORD,
+    DB_NAME
+} = process.env;
+
+// pool은 외부로 노출하지 않는다.
+// pool은 해당 서비스 내에서 유일하게 현재 모듈에서만 존재한다.
+const pool = mysql.createPool({
+    host : 'localhost',
+    user : DB_USER,
+    password : DB_PASSWORD,
+    database : DB_NAME,
+    port : 3306,
+    enableKeepAlive : true
+});
+
+// 해당 함수를 통해서만 sql을 실행할 수 있고, 그 외의 곳에서는 pool에서 connection을 획득하고 query를 날릴 수 없다.
+const query = async (sql, args) =>
+{
+    const con = await pool.getConnection();
+
+    const result = await con.query(sql, args);
+    con.release();
+
+    return result;
+}
+
+const endPool = () => pool.end();
+
+export
+{
+    query,
+    endPool
+};

--- a/db/select_as_field_from.js
+++ b/db/select_as_field_from.js
@@ -1,0 +1,17 @@
+import { query } from './db_helper.js';
+
+/**
+ * table에서 field 값을 가지는 레코드를 선택하여 그 중에 '첫 번째 요소'를 반환함
+ * 
+ * @param {string} table - nowkick 데이터베이스 내의 테이블명
+ * @param {string} fieldName - 선택할 레코드의 field 명
+ * @param {*} fieldValue - 선택할 레코드의 field 값(Mysql2 라이브러리가 지원하는 타입)
+ */
+const selectAsFieldFrom = async (table, fieldName, fieldValue) =>
+{
+    const result = await query("SELECT * FROM ?? WHERE ?? = ?", [table, fieldName, fieldValue]);
+
+    return result[0];
+};
+
+export default selectAsFieldFrom;

--- a/develop.env
+++ b/develop.env
@@ -1,3 +1,4 @@
+IS_SET=true
 DB_USER='nowkick'
 DB_PASSWORD=1234
 DB_NAME='nowkick'

--- a/lib/env_config.js
+++ b/lib/env_config.js
@@ -1,0 +1,13 @@
+import * as dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __rootPath = path.join(__dirname, '..');
+
+// 애플리케이션 실행 하면서 설정한 ENV_NAME 값 우선 사용, 존재하지 않을 경우 .env 사용
+const envPath = process.env.ENV_NAME || '.env';
+process.env.IS_SET || dotenv.config({ path : path.join(__rootPath, envPath) });
+
+export default null;

--- a/main.js
+++ b/main.js
@@ -1,12 +1,10 @@
 import express from 'express';
 import example from './router/example.js';
+import _ from './lib/env_config.js';
 
 const app = express();
 
 app.use('/example', example);
 app.get("/", (req, res) => res.end("Hello World!"));
 
-app.listen(3000, () => 
-{
-    console.log("server started!");
-});
+app.listen(3000, () => console.log("server started!"));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
-    "dev-start": "nodemon --watch * --ignore node_modules --exec npm start",
+    "dev-start": "set ENV_NAME=develop.env&&nodemon --watch * --ignore node_modules --exec npm start",
     "start": "node main.js"
   },
   "repository": {


### PR DESCRIPTION
## 관련 이슈

- close #3 

## 코드 변경 사항

1. mysql db 초기 연결을 담당하고 쿼리, 연결 종료 기능을 래핑하는 함수를 export하는 모듈 개발

2. npm run dev-start시 환경변수 ENV_NAME에 .env 파일의 이름 할당(개발 환경과 프로덕션 환경에서의 .env 파일 이름이 다르기 때문)

3. dotenv를 이용하여 서버 구동시 환경 변수 설정하도록 하는 모듈 구현(서버 구동시 처음에만 import함. 그 이후에 import 하더라도 다시 환경 변수를 설정하지는 않음)

4. 인자로 주어진 테이블의 대응되는 필드 값을 가지는 레코드 한 개를 가져오도록 하는 db select 래퍼 함수를 구현

## 기능 구현으로 인해 동작이 변경된 다른 부분

### 이제, 개발 환경에서는 __npm start__ 나 __node main.js__ 가 아닌 오로지 __npm run dev-start__ 만 사용해야 합니다

왜냐하면, npm start, node main.js를 통한 서버 애플리케이션 구동은 .env 파일의 부재로 인해 추후 내부 라이브러리, 모듈 사용시에 에러를 야기하게 되고 서버가 비정상 종료되게 됩니다.

현재 상황에서는 디렉터리에 .env 파일이 존재하지 않고, develop.env 밖에 존재하지 않는데 main.js 실행시 import 되는 env_config.js 모듈은 실행시 환경변수 ENV_NAME이 존재할 경우 ENV_NAME, 존재하지 않을 경우 .env 파일을 불러와서 환경 변수를 설정하기 때문입니다

추후에 .env 파일을 사용하게 되는 프로덕션 단계에 진입하면 .env 파일을 추가하고 npm start 스크립트도 변경해서 정상적으로 실행될 수 있도록 하겠습니다. node main.js도 그 때가 되면 정상 실행 가능합니다

- 참고 : 현재는 node main.js, npm start를 통한 실행으로도 서버가 정상적으로 구동되고 작동합니다. 다만, 설정된 환경 변수는 DB, private key 등을 위해 사용되기 때문에 관련 작업이 필요한 요청을 받게 되면 서버가 비정상 종료됩니다.

## 리뷰어에게

### @sinbak @jangjuntae @Byunjihun 

세 분 중 처음에 리뷰를 시작하시는 분은 오른쪽 사이드 바의 projects 탭에서 status를 __'In review'__ 로 변경하고 진행해주세요

### @sinbak 

- 해당 PR을 통해 추가되는 db/db_helper.js는 #2 의 기능을 개발하는데 사용할 필요가 없습니다
- 대신, db/select_as_field_from.js에 존재하는 selectAsFieldFrom 함수를 import 하여 기능을 구현해주시길 바랍니다

```
/**
 *
 */
```

위의 형식으로 되어있는 주석처럼 보이는 것은 JSDoc입니다. 여기에는 해당 함수나 변수 등에 대해서 그 형식이나 타입을 설명해놓았으니 참고하셔서 개발하시길 바랍니다.