### PR TITLE
[Chore, Feature] view template 관련 설정, 유저 프로필 사진 주소 공유를 위한 모듈

### DIFF
--- a/lib/user_profile.js
+++ b/lib/user_profile.js
@@ -1,0 +1,1 @@
+export const user_profile_image = 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTDLm7j389Kmf7rhrJzEJi9mqmihy0M32lnzg&usqp=CAU';

--- a/main.js
+++ b/main.js
@@ -1,8 +1,16 @@
 import _ from './lib/env_config.js';
 import express from 'express';
 import example from './router/example.js';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const viewPath = path.join(__dirname, 'view');
 
 const app = express();
+
+app.set('view engine', 'ejs');
+app.set('views', viewPath);
 
 app.use('/example', example);
 app.get("/", (req, res) => res.end("Hello World!"));


### PR DESCRIPTION
## 관련 이슈

- close #17 
- close #18  

## 코드 변경 사항

1. main.js에서 url, path 모듈로부터 fileURLToPath 함수와 path를 불러옵니다
2. path모듈과 fileURLToPath 함수를 이용해 main.js의 dirname을 구합니다
3. 해당 프로젝트 폴더의 view 폴더 경로를 생성해 viewPath에 할당합니다
4. app의 view engine을 ejs로 설정합니다
5. app의 views를 viewPath로 설정합니다
6. lib/user_profile.js는 user_profile_image를 export합니다 이는 외부 사이트 주소입니다

## 기능 구현으로 인해 동작이 변경된 다른 부분

이제 res.render를 하면 ejs 템플릿을 렌더링할 수 있습니다

## 리뷰어에게

우선순위 긴급! 신속 처리 요망!