### PR TITLE
[Feature] 경기 참가자 정보 조회 & 경기 정보 API

### DIFF
--- a/db/select_field.js
+++ b/db/select_field.js
@@ -1,0 +1,10 @@
+import { query } from './db_helper.js';
+
+/**
+ * 풋살 경기장 정보를 질의하는 함수
+ * @return {Promise<Array<RowDataPacket>>} 경기장 정보 레코드 배열
+ */
+const selectFutsalField = () =>
+    query('SELECT * FROM futsal_field');
+
+export { selectFutsalField };

--- a/db/select_match.js
+++ b/db/select_match.js
@@ -1,0 +1,11 @@
+import selectAsFieldFrom from './select_as_field_from.js';
+
+/**
+ * id에 해당하는 풋살 경기 정보를 질의하는 함수
+ * @param {Number} id - 경기 id, 1 이상의 정수여야 함
+ * @return {Promise<RowDataPacket>} id에 해당하는 경기 정보 레코드, id에 해당하는 경기가 없을 때는 undefined 반환
+ */
+const selectFutsalMatch = id => 
+    selectAsFieldFrom('futsal_match', 'id', id);
+
+export { selectFutsalMatch };

--- a/db/select_players_by_match.js
+++ b/db/select_players_by_match.js
@@ -1,0 +1,20 @@
+import { query } from './db_helper.js';
+
+/**
+ * 전달받은 matchId에 해당하는 경기의 모든 참가자들의 정보를 가져옴(match_id는 제외)
+ * 
+ * @param {Number} matchId - 경기 id, 1 이상의 정수여야 함
+ * @return {Promise<Array<RowDataPacket>>} 경기 참가자 정보 레코드 배열, query 결과가 존재하지 않을 때는 길이가 0
+ */
+const selectPlayersByMatch = matchId =>
+    query(`SELECT u.uid as uid, name, stuid, department, grade, gender 
+        FROM match_user as mu 
+        JOIN user as u 
+        ON mu.uid = u.uid 
+        WHERE match_id = ?`
+        , matchId);
+
+export 
+{
+    selectPlayersByMatch
+};

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,0 +1,23 @@
+/**
+ * 주어진 date의 시각 : 분 형식의 LocalTimeString을 반환하는 함수
+ * @param {Date} date - Date 객체
+ * @param {String|Array<String>} locales - locale 정보를 담고 있는 string 혹은 string 배열
+ * @return {String} 주어진 date의 LocalTimeString
+ */
+const getHM = (date, locales) =>
+    date.toLocaleTimeString(locales, { hour : 'numeric', minute : 'numeric', hour12 : false });
+
+/**
+ * 주어진 date의 년월일 요일을 나타내는 LocalDateString을 반환하는 함수
+ * @param {Date} date - Date 객체
+ * @param {String|Array<String>} locales - locale 정보를 담고 있는 string 혹은 string 배열
+ * @return {String} 주어진 date의 LocalDateString
+ */
+const getLongDateString = (date, locales) =>
+    date.toLocaleDateString(locales, { year : 'numeric', month : 'long', day : 'numeric', weekday : 'long' });
+
+export 
+{
+    getHM,
+    getLongDateString
+};

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import _ from './lib/env_config.js';
 import express from 'express';
 import example from './router/example.js';
+import match from './router/match.js';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -13,6 +14,8 @@ app.set('view engine', 'ejs');
 app.set('views', viewPath);
 
 app.use('/example', example);
+app.use('/match', match);
+
 app.get("/", (req, res) => res.end("Hello World!"));
 
 app.listen(3000, () => console.log("server started!"));

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ const app = express();
 app.set('view engine', 'ejs');
 app.set('views', viewPath);
 
+app.use(express.static('public'));
 app.use('/example', example);
 app.use('/match', match);
 

--- a/router/match.js
+++ b/router/match.js
@@ -1,0 +1,7 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/:matchId', (req, res) => res.end(req.params.matchId + ' confirmed'));
+
+export default router;

--- a/router/match.js
+++ b/router/match.js
@@ -1,7 +1,70 @@
 import express from 'express';
+import { selectFutsalMatch } from '../db/select_match.js';
+import { selectFutsalField } from '../db/select_field.js';
+import { selectPlayersByMatch } from '../db/select_players_by_match.js';
+import { user_profile_image } from '../lib/user_profile.js';
+import { getHM, getLongDateString } from '../lib/date.js';
 
 const router = express.Router();
 
-router.get('/:matchId', (req, res) => res.end(req.params.matchId + ' confirmed'));
+router.get('/:matchId',
+    (req, res, next) =>                       // matchId의 유효성 검사(1 이상의 정수)
+    {
+        const matchId = Number(req.params.matchId);
+        const statusDefaultText = '400 Bad Request';
+
+        // matchId가 정수인지 검사
+        // 파라미터 matchId가 정수 형태의 문자열인지 검사
+        if(!Number.isSafeInteger(matchId) || req.params.matchId.indexOf('.') !== -1)
+            return res.status(400).send(statusDefaultText + ', matchId is Unsigned Int');
+        if(matchId < 1)
+            return res.status(400).send(statusDefaultText + ', matchId is over 1');
+        next();
+    },
+    async (req, res) =>
+    {
+        const matchId = Number(req.params.matchId);
+        const statusDefaultText = { notFound : '404 Not Found' };
+
+        try
+        {
+            const matchRecord = await selectFutsalMatch(matchId);
+
+            // matchId에 해당하는 match가 존재하지 않을 때의 예외 처리
+            if(matchRecord === undefined)
+                return res.status(404).send(statusDefaultText.notFound + ', match Not Found');
+
+            const [ [ fieldRecord ], playerRecords ] = await Promise.all([ selectFutsalField(), selectPlayersByMatch(matchId) ]);
+            
+            // stuid를 입학 년도에 대한 학번으로 변경
+            // user_info_link, user_profile_image 정보 추가
+            const players =  playerRecords
+                            .map(player => 
+                                Object.assign(
+                                    player, 
+                                    {
+                                        stuid : String(player.stuid).slice(2, 4),
+                                        user_info_link : `/user/${player.uid}`, 
+                                        user_profile_image 
+                                    }));
+            
+            // 템플릿 렌더링
+            return res.render('match_info.ejs', 
+                {
+                    match_date : getLongDateString(matchRecord.start_time, 'ko-KR'),
+                    play_time : matchRecord.play_time,
+                    start_time : getHM(matchRecord.start_time, 'ko-KR'),
+                    end_time : getHM(matchRecord.end_time, 'ko-KR'),
+                    location : fieldRecord.location,
+                    current_member : matchRecord.current_member,
+                    players
+                });
+        }
+        catch(e)
+        {
+            console.log(e);
+            return res.status(500).send('500 Internal Server Error Occured!');
+        }
+    });
 
 export default router;


### PR DESCRIPTION
## 관련 이슈

- close #13 
- close #8 

## 코드 변경 사항

- 경기 참가자 정보 조회

1. 경기의 id(matchId)를 입력받으면 해당 경기의 모든 참가자 정보를 select해 반환하는 selectPlayersByMatch 함수 구현
2. '/match/:matchId' 형식의 url로 HTTP Get 요청을 보내면 해당 경기 정보 페이지를 렌더링하여 응답하는 라우터 핸들러 구현
3. 라우터 핸들러에서 미들웨어를 통해 파라미터 matchId에 대한 유효성 검사(1 이상의 정수일 것)를 실시하고 잘못된 값을 입력 시 400 Bad Request로 응답하도록 구현 함
4. 경기 정보, 경기장 정보를 DB에서 가져오기 위해 selectFutsalMatch(matchId), selectFutsalField() 함수를 구현함
5. 경기 날짜, 경기 시각 등의 정보를 Date 객체로부터 문자열 형태로 가져오기 위한 date.js 모듈과 getHM, getLongDateString 함수 구현(HM은 시각과 분, LongDateString은 년월일요일을 문자열 형태로 표시) 
6. css, image 등의 정적 파일 제공을 위해 서버 애플리케이션이 public 폴더를 통해 정적 파일을 제공하도록 설정함

## 변경 이전, 이후의 프로그램 동작에 대한 스크린샷

- #21 의 스크린샷 부분 참고 바람

## 기능 구현으로 인해 동작이 변경된 다른 부분

1. 서버 애플리케이션이 /match/:matchId에 대해서 적절한 페이지를 제공합니다
2. public 폴더를 정적 파일 폴더로 설정하였습니다. 따라서 앞으로 public 폴더에는 사용자에게 제공할 수 있는 정적 파일만 존재해야 합니다. 또한, public 폴더에 존재하는 모든 파일은 사용자가 url을 통해 접근, 열람, 획득할 수 있습니다

## issue와는 다른, 혹은 추가된 구현 사항

1. #8 에서는 selectPlayersByMatch 함수에서 matchId의 유효성 검사를 하는 것으로 정의하였으나 실제 API 구현 중 중복 검증을 수행하게 되어 selectPlayersByMatch가 아닌 라우터 핸들러에서 middleware로 유효성 검증을 수행하는 것으로 변경하였습니다
2. date.js가 Date 객체로부터 정보 문자열을 가져오기 위해 추가되었습니다(date.js)
3. selectFutsalField, selectFutsalMatch 함수가 issue에는 명시되지 않았지만 구현의 과정에서 추가되었습니다(db/select_field.js, db/select_match.js)
4. 정적 파일 제공을 위한 설정이 추가되었습니다(main.js)

## 검증 완료된 사항

1. 경기 참가자가 0명인 상황에서 players를 빈 배열로 할당하여 match_info.ejs를 렌더링 하였을 때 정상적으로 렌더링되고 참가자 정보 뷰는 포함되지 않는 것을 확인하였습니다